### PR TITLE
Fix: Tiptap ordered and unordered lists not rendering

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -5,3 +5,14 @@
 .no-border-width {
     border-width: 0 !important;
 }
+
+/* Add styles for Tiptap editor content */
+.tiptap ul {
+    list-style-type: disc;
+    margin-left: 20px;
+}
+
+.tiptap ol {
+    list-style-type: decimal;
+    margin-left: 20px;
+}

--- a/src/lib/components/ResumePreview.svelte
+++ b/src/lib/components/ResumePreview.svelte
@@ -61,7 +61,7 @@
           
           {#if resumeData.personal.summary}
             <div class="mt-4">
-              <div class="text-gray-700">{@html resumeData.personal.summary}</div>
+              <div class="text-gray-700 tiptap">{@html resumeData.personal.summary}</div>
             </div>
           {/if}
         </div>
@@ -80,7 +80,7 @@
                   </div>
                   <p class="text-gray-700">{exp.company || 'Company'}</p>
                   {#if exp.description}
-                    <div class="mt-1 text-sm text-gray-600">{@html exp.description}</div>
+                    <div class="mt-1 text-sm text-gray-600 tiptap">{@html exp.description}</div>
                   {/if}
                 </div>
               {/if}
@@ -102,7 +102,7 @@
                   </div>
                   <p class="text-gray-700">{edu.institution || 'Institution'}</p>
                   {#if edu.description}
-                    <div class="mt-1 text-sm text-gray-600">{@html edu.description}</div>
+                    <div class="mt-1 text-sm text-gray-600 tiptap">{@html edu.description}</div>
                   {/if}
                 </div>
               {/if}
@@ -191,7 +191,7 @@
             {#if resumeData.personal.summary}
               <div class="mb-6">
                 <h2 class="text-xl font-semibold text-purple-800 mb-2 border-b border-purple-200 pb-1">About Me</h2>
-                <div class="text-gray-700">{@html resumeData.personal.summary}</div>
+                <div class="text-gray-700 tiptap">{@html resumeData.personal.summary}</div>
               </div>
             {/if}
             
@@ -210,7 +210,7 @@
                       </div>
                       <p class="text-gray-700">{exp.company || 'Company'}</p>
                       {#if exp.description}
-                        <div class="mt-1 text-sm text-gray-600">{@html exp.description}</div>
+                        <div class="mt-1 text-sm text-gray-600 tiptap">{@html exp.description}</div>
                       {/if}
                     </div>
                   {/if}
@@ -233,7 +233,7 @@
                       </div>
                       <p class="text-gray-700">{edu.institution || 'Institution'}</p>
                       {#if edu.description}
-                        <div class="mt-1 text-sm text-gray-600">{@html edu.description}</div>
+                        <div class="mt-1 text-sm text-gray-600 tiptap">{@html edu.description}</div>
                       {/if}
                     </div>
                   {/if}
@@ -268,7 +268,7 @@
           
           {#if resumeData.personal.summary}
             <div class="mb-6">
-              <div class="text-gray-700">{@html resumeData.personal.summary}</div>
+              <div class="text-gray-700 tiptap">{@html resumeData.personal.summary}</div>
             </div>
           {/if}
           
@@ -288,7 +288,7 @@
                     </div>
                     <p class="text-gray-700">{exp.company || 'Company'}</p>
                     {#if exp.description}
-                      <div class="mt-2 text-sm text-gray-600">{@html exp.description}</div>
+                      <div class="mt-2 text-sm text-gray-600 tiptap">{@html exp.description}</div>
                     {/if}
                   </div>
                 {/if}
@@ -312,7 +312,7 @@
                     </div>
                     <p class="text-gray-700">{edu.institution || 'Institution'}</p>
                     {#if edu.description}
-                      <div class="mt-2 text-sm text-gray-600">{@html edu.description}</div>
+                      <div class="mt-2 text-sm text-gray-600 tiptap">{@html edu.description}</div>
                     {/if}
                   </div>
                 {/if}
@@ -392,7 +392,7 @@
               {#if resumeData.personal.summary}
                 <div class="mb-6">
                   <h2 class="text-lg font-semibold border-b border-gray-300 pb-2 mb-3">Professional Summary</h2>
-                  <div class="text-gray-700">{@html resumeData.personal.summary}</div>
+                  <div class="text-gray-700 tiptap">{@html resumeData.personal.summary}</div>
                 </div>
               {/if}
               
@@ -410,7 +410,7 @@
                         </div>
                         <p class="text-gray-700 italic">{exp.position || 'Position'}</p>
                         {#if exp.description}
-                          <div class="mt-2 text-sm text-gray-700">{@html exp.description}</div>
+                          <div class="mt-2 text-sm text-gray-700 tiptap">{@html exp.description}</div>
                         {/if}
                       </div>
                     {/if}
@@ -432,7 +432,7 @@
                         </div>
                         <p class="text-gray-700">{edu.degree || 'Degree'}{edu.field ? ` in ${edu.field}` : ''}</p>
                         {#if edu.description}
-                          <div class="mt-1 text-sm text-gray-600">{@html edu.description}</div>
+                          <div class="mt-1 text-sm text-gray-600 tiptap">{@html edu.description}</div>
                         {/if}
                       </div>
                     {/if}

--- a/src/lib/components/TiptapEditor.svelte
+++ b/src/lib/components/TiptapEditor.svelte
@@ -42,8 +42,14 @@
     <button on:click={() => editor.chain().focus().toggleStrike().run()} class:is-active={editor?.isActive('strike')}>
       Strike
     </button>
+    <button on:click={() => editor.chain().focus().toggleBulletList().run()} class:is-active={editor?.isActive('bulletList')}>
+      Bullet List
+    </button>
+    <button on:click={() => editor.chain().focus().toggleOrderedList().run()} class:is-active={editor?.isActive('orderedList')}>
+      Ordered List
+    </button>
   </div>
-  <div bind:this={element}></div>
+  <div bind:this={element} class="tiptap"></div>
 </div>
 
 <style>


### PR DESCRIPTION
The ordered and unordered lists you created in the Tiptap editor were not being rendered correctly in the resume preview. This was because the default browser styles for `ul` and `ol` elements were being reset by Tailwind CSS, and no custom styles were being applied.

This commit fixes the issue by:

1.  Adding CSS styles for `ul` and `ol` elements to `src/app.css`.
2.  Applying the `tiptap` class to the `div` elements that render the HTML content in `ResumePreview.svelte`.
3.  Adding buttons to the `TiptapEditor.svelte` component to allow you to add and remove ordered and unordered lists.