### PR TITLE
fix: Improve PDF export rendering for underlines and spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@sveltejs/kit": "^2.25.1",
     "@sveltejs/vite-plugin-svelte": "latest",
     "@tiptap/core": "2.26.1",
+    "@tiptap/extension-underline": "2.26.1",
     "@tiptap/pm": "2.26.1",
     "@tiptap/starter-kit": "2.26.1",
     "@types/quill": "^2.0.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@tiptap/core':
         specifier: 2.26.1
         version: 2.26.1(@tiptap/pm@2.26.1)
+      '@tiptap/extension-underline':
+        specifier: 2.26.1
+        version: 2.26.1(@tiptap/core@2.26.1(@tiptap/pm@2.26.1))
       '@tiptap/pm':
         specifier: 2.26.1
         version: 2.26.1
@@ -909,6 +912,11 @@ packages:
 
   '@tiptap/extension-text@2.26.1':
     resolution: {integrity: sha512-p2n8WVMd/2vckdJlol24acaTDIZAhI7qle5cM75bn01sOEZoFlSw6SwINOULrUCzNJsYb43qrLEibZb4j2LeQw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-underline@2.26.1':
+    resolution: {integrity: sha512-/fufv41WDMdf0a4xmFAxONoAz08TonJXX6NEoSJmuGKO59M/Y0Pz8DTK1g32Wk44kn7dyScDiPlvvndl+UOv0A==}
     peerDependencies:
       '@tiptap/core': ^2.7.0
 
@@ -2953,6 +2961,10 @@ snapshots:
       '@tiptap/core': 2.26.1(@tiptap/pm@2.26.1)
 
   '@tiptap/extension-text@2.26.1(@tiptap/core@2.26.1(@tiptap/pm@2.26.1))':
+    dependencies:
+      '@tiptap/core': 2.26.1(@tiptap/pm@2.26.1)
+
+  '@tiptap/extension-underline@2.26.1(@tiptap/core@2.26.1(@tiptap/pm@2.26.1))':
     dependencies:
       '@tiptap/core': 2.26.1(@tiptap/pm@2.26.1)
 

--- a/src/lib/components/TiptapEditor.svelte
+++ b/src/lib/components/TiptapEditor.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy, createEventDispatcher } from 'svelte';
   import { Editor } from '@tiptap/core';
   import StarterKit from '@tiptap/starter-kit';
+  import Underline from '@tiptap/extension-underline';
   import type { Editor as EditorType } from '@tiptap/core';
 
   export let value: string;
@@ -15,6 +16,7 @@
       element: element,
       extensions: [
         StarterKit,
+        Underline,
       ],
       content: value,
       onUpdate: () => {
@@ -41,6 +43,9 @@
     </button>
     <button on:click={() => editor.chain().focus().toggleStrike().run()} class:is-active={editor?.isActive('strike')}>
       Strike
+    </button>
+    <button on:click={() => editor.chain().focus().toggleUnderline().run()} class:is-active={editor?.isActive('underline')}>
+      Underline
     </button>
     <button on:click={() => editor.chain().focus().toggleBulletList().run()} class:is-active={editor?.isActive('bulletList')}>
       Bullet List

--- a/src/routes/builder/+page.svelte
+++ b/src/routes/builder/+page.svelte
@@ -57,7 +57,8 @@
         scale: 2,
         backgroundColor: '#ffffff',
         useCORS: true,
-        logging: false
+        logging: false,
+        removeContainer: false
       });
       
       const imgData = canvas.toDataURL('image/png');


### PR DESCRIPTION
This commit addresses two issues with the PDF export functionality:

1.  **Underline rendering:** The Tiptap editor did not have built-in support for underlines. This change adds the `@tiptap/extension-underline` package and includes it in the editor, along with a toolbar button. This ensures that underlines are handled consistently.

2.  **Spacing issues:** The `html2canvas` library, which is used to render the resume for PDF export, can sometimes have issues with element spacing. The `removeContainer: false` option has been added to the `html2canvas` configuration to prevent the canvas from being moved in the DOM during rendering, which can help mitigate layout and spacing problems.